### PR TITLE
update: dependencies and kotlin version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Setup JDK 1.8
+      - name: Setup JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Build unsigned APK
         run: ./gradlew assemble

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Setup JDK 1.8
+      - name: Setup JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache
         uses: actions/cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Setup JDK 1.8
+      - name: Setup JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache
         uses: actions/cache@v1

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,17 +66,17 @@ android {
 dependencies {
     //Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
 
     // Android
-    implementation 'androidx.core:core-ktx:1.7.0-alpha01'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
-    implementation 'androidx.preference:preference-ktx:1.1.1'
+    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
+    implementation 'androidx.preference:preference-ktx:1.2.0'
     implementation 'androidx.security:security-crypto:1.1.0-alpha03'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
     // FlowBinding
     implementation "io.github.reactivecircus.flowbinding:flowbinding-android:$flowbinding_version"
@@ -90,7 +90,7 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation "com.squareup.retrofit2:converter-scalars:2.4.0"
     implementation 'com.github.MohammadSianaki:Retrofit2-Flow-Call-Adapter:0.2.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.2'
+    implementation 'com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.5'
 
     // Blockstack
     //noinspection GradleDependency
@@ -116,7 +116,7 @@ dependencies {
     }
 
     // Material Design
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'com.google.android.material:material:1.5.0'
 
     // Glide
     implementation 'com.github.bumptech.glide:glide:4.12.0'
@@ -126,10 +126,9 @@ dependencies {
     implementation "com.google.dagger:hilt-android:$dagger_hilt_version"
     kapt "com.google.dagger:hilt-compiler:$dagger_hilt_version"
     kapt "androidx.hilt:hilt-compiler:$androidx_hilt_version"
-    implementation "androidx.hilt:hilt-lifecycle-viewmodel:$androidx_hilt_version"
 
     // Logging
-    implementation 'com.jakewharton.timber:timber:4.7.1'
+    implementation 'com.jakewharton.timber:timber:5.0.1'
 
     // Testing
     testImplementation 'junit:junit:4.13.2'
@@ -141,8 +140,8 @@ dependencies {
     kaptTest "com.google.dagger:hilt-android-compiler:$dagger_hilt_version"
 
     // Instrumentation Testing
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation  "com.google.dagger:hilt-android-testing:$dagger_hilt_version"
     kaptAndroidTest "com.google.dagger:hilt-android-compiler:$dagger_hilt_version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        kotlin_version = "1.4.30"
+        kotlin_version = "1.6.10"
         kethereum_version = '0.76.1'
         did_jwt_version = '0.3.2'
         blockstack_version = 'a970880'
         flowbinding_version = '1.0.0-beta02'
-        dagger_hilt_version = '2.31-alpha'
+        dagger_hilt_version = '2.41'
         androidx_hilt_version = '1.0.0-alpha03'
     }
 
@@ -15,9 +15,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.29.1-alpha'
+        classpath "com.google.dagger:hilt-android-gradle-plugin:$dagger_hilt_version"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip


### PR DESCRIPTION
Kotlin version updated: from 1.4.3 to 1.6.10
Dagger hilt version: from 2.31-alpha to 2.41
AGP from 4.2.1 to 7.1.2
Gradle from 6.7.1 to 7.2

Updated dependencies:
- androidx.core:core-ktx:1.7.0-alpha01 to 1.7.0
- org.jetbrains.kotlinx:kotlinx-coroutines-core from 1.4.1 to 1.5.2
- androidx.appcompat:appcompat from 1.3.1 to 1.4.1
- androidx.coordinatorlayout:coordinatorlayout from 1.1.0 to 1.2.0
- androidx.preference:preference-ktx from 1.1.0 to 1.2.0
- androidx.lifecycle:lifecycle-viewmodel-ktx from 2.3.1 to 2.4.1
- androidx.lifecycle:lifecycle-runtime-ktx from 2.3.1 to 2.4.1
- androidx.constraintlayout:constraintlayout from 2.1.0 to 2.1.3
- com.google.android.material:material from 1.3.0 to 1.5.0
- com.jakewharton.timber:timber from 4.7.1 to 5.0.1
- androidx.test.ext:junit from 1.1.2 to 1.1.3
- androidx.test.espresso:espresso-core from 3.3.0 to 3.4.0
- com.squareup.okhttp3:logging-interceptor from 5.0.0-alpha.2 to 5.0.0-alpha.5

Removed dependencies: 
androidx.hilt:hilt-lifecycle-viewmodel (no longer needed)